### PR TITLE
Substitute RootCA and RootAuth into Untrusted each storage then make it work.

### DIFF
--- a/NoGPKI/MainWindow.xaml.cs
+++ b/NoGPKI/MainWindow.xaml.cs
@@ -68,22 +68,57 @@ namespace NoGPKI
             var lm_certs = lmban.Certificates.Find(X509FindType.FindByThumbprint, gpkiCert.Thumbprint, false);
             var cu_certs = cuban.Certificates.Find(X509FindType.FindByThumbprint, gpkiCert.Thumbprint, false);
 
-            if ((lm_certs != null && lm_certs.Count > 0) || (cu_certs != null && cu_certs.Count > 0))
+            bool found_cucerts = false;
+            bool found_lmcerts = false;
+            bool found_abnormality = false;
+
+            if (lm_certs != null && lm_certs.Count > 0)
             {
                 if (lm_certs[0].PrivateKey == gpkiCert.PrivateKey)
                 {
+                    found_lmcerts = true;
+                }
+                else
+                {
+                    found_abnormality = true;
+                }
+            }
+
+            if (cu_certs != null && cu_certs.Count > 0)
+            {
+                if (cu_certs[0].PrivateKey == gpkiCert.PrivateKey)
+                {
+                    found_cucerts = true;
+                }
+                else
+                {
+                    found_abnormality = true;
+                }
+            }
+
+            if (found_cucerts || found_lmcerts)
+            {
+                if(found_cucerts != found_lmcerts)
+                {
+                    certStat.Content = "GPKI인증서를 불신, 일부만 적용됨";
+                    statusLabel.Content = "준비 완료! 명령만 주세요!";
+                }
+                else
+                {
                     certStat.Content = "비밀키가 일치하는 GPKI인증서 발견됨";
                     statusLabel.Content = "준비 완료! 명령만 주세요!";
-                } else
-                {
-                    certStat.Content = "지문만 일치하는 GPKI인증서 발견됨";
-                    statusLabel.Content = "뭔가 이상해요! README를 읽어봐요!";
                 }
-                statusLabel.Content += (lm_certs != null && lm_certs.Count > 0) ? "(LM+)":" (LM)";
-            } else
+            }
+            else
             {
-                certStat.Content = "GPKI인증서가 발견되지 않음.";
+                certStat.Content = "GPKI인증서를 신뢰하고 있음";
                 statusLabel.Content = "준비 완료! 명령만 주세요!";
+            }
+
+            if (found_abnormality)
+            {
+
+                statusLabel.Content = "뭔가 이상해요! README를 읽어봐요!";
             }
             
         }

--- a/NoGPKI/MainWindow.xaml.cs
+++ b/NoGPKI/MainWindow.xaml.cs
@@ -59,8 +59,6 @@ namespace NoGPKI
 
         public MainWindow()
         {
-            OpenStores();
-
             if (!VerifyIsGPKI())
             {
                 GPKICheckSumFail();
@@ -71,11 +69,14 @@ namespace NoGPKI
 
             InitializeComponent();
 
+            // empty statusLabel on init;
+            statusLabel.Content = "";
             checkGPKIstatus();
         }
 
         public void checkGPKIstatus()
         {
+            OpenStores();
 
             var lm_certs = lmban.Certificates.Find(X509FindType.FindByThumbprint, gpkiCert.Thumbprint, false);
             var cu_certs = cuban.Certificates.Find(X509FindType.FindByThumbprint, gpkiCert.Thumbprint, false);
@@ -87,6 +88,8 @@ namespace NoGPKI
             int err_certs = 0;
             if (lm_certs != null && lm_certs.Count > 0)
             {
+                Console.WriteLine(lm_certs[0].PrivateKey);
+                Console.WriteLine(gpkiCert.PrivateKey);
                 if (lm_certs[0].PrivateKey == gpkiCert.PrivateKey)
                 {
                     found_lmcerts = true;
@@ -119,31 +122,34 @@ namespace NoGPKI
                 err_certs -= FLAG_TRUST_ON_CU; // -8, trusted on cu
             }
 
+            string msg_to_append = "";
             if (found_cucerts || found_lmcerts)
             {
                 if (found_cucerts != found_lmcerts)
                 {
                     certStat.Content = "GPKI인증서를 불신, 일부만 적용됨";
-                    statusLabel.Content = "준비 완료! 명령만 주세요!";
+                    msg_to_append = "준비 완료! 명령만 주세요!";
                 }
                 else
                 {
-                    certStat.Content = "비밀키가 일치하는 GPKI인증서 발견";
-                    statusLabel.Content = "준비 완료! 명령만 주세요!";
+                    certStat.Content = "비밀키 일치 GPKI인증서 불신중";
+                    msg_to_append = "준비 완료! 명령만 주세요!";
                 }
             }
             else
             {
                 certStat.Content = "GPKI인증서를 신뢰하고 있음";
-                statusLabel.Content = "준비 완료! 명령만 주세요!";
+                msg_to_append = "준비 완료! 명령만 주세요!";
             }
 
             if (found_abnormality)
             {
-                statusLabel.Content = "뭔가 이상해요! README를 읽어봐요!";
+                msg_to_append = "뭔가 이상해요! README를 읽어봐요!";
             }
+            statusLabel.Content += "\n";
+            statusLabel.Content += msg_to_append;
 
-            if(err_certs != 0)
+            if (err_certs != 0)
             {
                 // with partial untrust or with abnormality
                 // error code will be appended

--- a/NoGPKI/MainWindow.xaml.cs
+++ b/NoGPKI/MainWindow.xaml.cs
@@ -31,10 +31,10 @@ namespace NoGPKI
         public string gpkiPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),"assets\\gpkiroot.cer");
         public X509Certificate2 gpkiCert;
 
-        public const int FLAG_FAIL_ON_LM = 0b0001;
-        public const int FLAG_FAIL_ON_CU = 0b0010;
-        public const int FLAG_TRUST_ON_LM = 0b0100;
-        public const int FLAG_TRUST_ON_CU = 0b1000;
+        public const int FLAG_FAIL_ON_LM = 0b0001;  // 1, used to flag fail on lm
+        public const int FLAG_FAIL_ON_CU = 0b0010;  // 2, used to flag fail on cu
+        public const int FLAG_TRUST_ON_LM = 0b0100; // 4, used to flag trust on lm
+        public const int FLAG_TRUST_ON_CU = 0b1000; // 8, used to flag trust on cu
 
 
         public void OpenStores()

--- a/NoGPKI/MainWindow.xaml.cs
+++ b/NoGPKI/MainWindow.xaml.cs
@@ -88,8 +88,6 @@ namespace NoGPKI
             int err_certs = 0;
             if (lm_certs != null && lm_certs.Count > 0)
             {
-                Console.WriteLine(lm_certs[0].PrivateKey);
-                Console.WriteLine(gpkiCert.PrivateKey);
                 if (lm_certs[0].PrivateKey == gpkiCert.PrivateKey)
                 {
                     found_lmcerts = true;

--- a/NoGPKI/MainWindow.xaml.cs
+++ b/NoGPKI/MainWindow.xaml.cs
@@ -31,6 +31,12 @@ namespace NoGPKI
         public string gpkiPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),"assets\\gpkiroot.cer");
         public X509Certificate2 gpkiCert;
 
+        public const int FLAG_FAIL_ON_LM = 0b0001;
+        public const int FLAG_FAIL_ON_CU = 0b0010;
+        public const int FLAG_TRUST_ON_LM = 0b0100;
+        public const int FLAG_TRUST_ON_CU = 0b1000;
+
+
         public void OpenStores()
         {
             try
@@ -88,12 +94,12 @@ namespace NoGPKI
                 else
                 {
                     found_abnormality = true;
-                    err_certs -= 0b0001; // -1, abnormality on lm
+                    err_certs -= FLAG_FAIL_ON_LM; // -1, abnormality on lm
                 }
             }
             else
             {
-                err_certs -= 0b0100; // -4, trusted on lm 
+                err_certs -= FLAG_TRUST_ON_LM; // -4, trusted on lm 
             }
 
             if (cu_certs != null && cu_certs.Count > 0)
@@ -105,12 +111,12 @@ namespace NoGPKI
                 else
                 {
                     found_abnormality = true;
-                    err_certs -= 0b0010; // -2, abnormality on cu
+                    err_certs -= FLAG_FAIL_ON_CU; // -2, abnormality on cu
                 }
             }
             else
             {
-                err_certs -= 0b1000; // -8, trusted on cu
+                err_certs -= FLAG_TRUST_ON_CU; // -8, trusted on cu
             }
 
             if (found_cucerts || found_lmcerts)
@@ -230,7 +236,7 @@ namespace NoGPKI
                 }
                 catch
                 {
-                    err_trust -= 0b0001;   // -1, lm removal fail
+                    err_trust -= FLAG_FAIL_ON_LM;   // -1, lm removal fail
                 }
                 statusProgress.Value = 60;
     
@@ -241,7 +247,7 @@ namespace NoGPKI
                 }
                 catch
                 {
-                    err_trust -= 0b0010;   // -2, cu removal fail
+                    err_trust -= FLAG_FAIL_ON_CU;   // -2, cu removal fail
                 }
                 statusProgress.Value = 80;
 
@@ -293,7 +299,7 @@ namespace NoGPKI
                 }
                 catch
                 {
-                    err_ban -= 0b0001;   // -1, lm ban fail
+                    err_ban -= FLAG_FAIL_ON_LM;   // -1, lm ban fail
                 }
                 statusProgress.Value = 60;
 
@@ -304,7 +310,7 @@ namespace NoGPKI
                 }
                 catch
                 {
-                    err_ban -= 0b0010;   // -2, cu ban fail
+                    err_ban -= FLAG_FAIL_ON_CU;   // -2, cu ban fail
                 }
                 statusProgress.Value = 80;
                                 


### PR DESCRIPTION
It is safe to handle only untrusted because MS Windows restores GPKI into RootCA and RootAuth frequently so no worries about deletion of those.